### PR TITLE
use ACCEPT in add_allowed_*

### DIFF
--- a/root/etc/init.d/dockerman
+++ b/root/etc/init.d/dockerman
@@ -14,11 +14,11 @@ init_dockerman_chain(){
 }
 
 add_allowed_interface(){
-	iptables -A DOCKER-MAN -i $1 -o docker0 -j RETURN
+	iptables -A DOCKER-MAN -i $1 -o docker0 -j ACCEPT
 }
 
 add_allowed_ip(){
-	iptables -A DOCKER-MAN -d $1 -o docker0 -j RETURN
+	iptables -A DOCKER-MAN -d $1 -o docker0 -j ACCEPT
 }
 
 handle_allowed_interface(){


### PR DESCRIPTION
According the docker doc
https://docs.docker.com/network/iptables/#docker-on-a-router
Docker also sets the policy for the FORWARD chain to DROP.
If we use RETURN, the allowed interface can't visit the containers directly and must visit the expose port.

PS: Maybe add a button to choose "Could allowed interface can visit the containers directly" looks better?