### PR TITLE
添加CGROUP为默认选取依赖

### DIFF
--- a/applications/luci-app-dockerman/Makefile
+++ b/applications/luci-app-dockerman/Makefile
@@ -8,6 +8,7 @@ LUCI_DEPENDS:=@(aarch64||arm||x86_64) \
 	+docker \
 	+dockerd \
 	+ttyd
+	+DOCKER_CGROUP_OPTIONS
 LUCI_PKGARCH:=all
 
 PKG_LICENSE:=AGPL-3.0


### PR DESCRIPTION
添加CGROUP为默认选取依赖，如果遗漏，会导致docker daemon无法启动，只显示配置一个选项