### PR TITLE
Use procd

### DIFF
--- a/applications/luci-app-dockerman/luasrc/model/cbi/dockerman/configuration.lua
+++ b/applications/luci-app-dockerman/luasrc/model/cbi/dockerman/configuration.lua
@@ -121,9 +121,22 @@ if nixio.fs.access("/usr/bin/dockerd") and not m.uci:get_bool("dockerd", "docker
 		o:value(v, v)
 	end
 	o = s:taboption("ac", DynamicList, "ac_allowed_container", translate("Containers allowed to be accessed"), translate("Which container(s) under bridge network can be accessed, even from interfaces that are not allowed, fill-in Container Id or Name"))
+	local docker = require "luci.model.docker"
+	local containers, res, lost_state
+	local dk = docker.new()
+	if dk:_ping().code ~= 200 then
+		lost_state = true
+	else
+		lost_state = false
+		res = dk.containers:list()
+		if res and res.code and res.code < 300 then
+			containers = res.body
+		end
+	end
+
 	-- allowed_container.placeholder = "container name_or_id"
-	if containers_list then
-		for i, v in ipairs(containers_list) do
+	if containers then
+		for i, v in ipairs(containers) do
 			if	v.State == "running" and v.NetworkSettings and v.NetworkSettings.Networks and v.NetworkSettings.Networks.bridge and v.NetworkSettings.Networks.bridge.IPAddress then
 				o:value(v.Id:sub(1,12), v.Names[1]:sub(2) .. " | " .. v.NetworkSettings.Networks.bridge.IPAddress)
 			end

--- a/applications/luci-app-dockerman/root/etc/init.d/dockerman
+++ b/applications/luci-app-dockerman/root/etc/init.d/dockerman
@@ -1,6 +1,7 @@
 #!/bin/sh /etc/rc.common
 
 START=99
+USE_PROCD=1
 
 config_load dockerd
 # config_get daemon_ea "dockerman" daemon_ea
@@ -28,11 +29,19 @@ handle_allowed_interface(){
 	iptables -A DOCKER-MAN -j RETURN >/dev/null 2>&1
 }
 
-start(){
+start_service(){
 	[ ! -x "/etc/init.d/dockerd" ] && return 0
 	init_dockerman_chain
 	# if [ -n "$daemon_ea" ]; then
 	handle_allowed_interface
 	lua /usr/share/dockerman/dockerd-ac.lua
 	# fi
+}
+
+service_triggers() {
+	procd_add_reload_trigger 'dockerd'
+}
+
+reload_service() {
+	start
 }


### PR DESCRIPTION
1. dockerman script use procd：在/etc/init.d/dockerman脚本中使用USE_PROCD，在luci页面内点击"Save&Apply"（保存并应用）后，能触发/etc/init.d/dockerman reload
2. 修复ac_allowed_container配置的luci界面