### PR TITLE
container console considers ttyd ssl config

### DIFF
--- a/applications/luci-app-dockerman/luasrc/model/cbi/dockerman/container.lua
+++ b/applications/luci-app-dockerman/luasrc/model/cbi/dockerman/container.lua
@@ -715,6 +715,14 @@ elseif action == "console" then
 				return
 			end
 
+			local ttyd_ssl = uci.get("ttyd", "@ttyd[0]", "ssl")
+			local ttyd_ssl_key = uci.get("ttyd", "@ttyd[0]", "ssl_key")
+			local ttyd_ssl_cert = uci.get("ttyd", "@ttyd[0]", "ssl_cert")
+
+			if ttyd_ssl=="1" and ttyd_ssl_cert and ttyd_ssl_key then
+				cmd_ttyd=string.format('%s -S -C %s -K %s',cmd_ttyd,ttyd_ssl_cert,ttyd_ssl_key)
+			end
+
 			local pid = luci.util.trim(luci.util.exec("netstat -lnpt | grep :7682 | grep ttyd | tr -s ' ' | cut -d ' ' -f7 | cut -d'/' -f1"))
 			if pid and pid ~= "" then
 				luci.util.exec("kill -9 " .. pid)

--- a/applications/luci-app-dockerman/luasrc/view/dockerman/container_console.htm
+++ b/applications/luci-app-dockerman/luasrc/view/dockerman/container_console.htm
@@ -2,5 +2,5 @@
 	<iframe id="terminal" style="width: 100%; min-height: 500px; border: none; border-radius: 3px;"></iframe>
 </div>
 <script type="text/javascript">
-	document.getElementById("terminal").src = "http://" + window.location.hostname + ":7682";
+	document.getElementById("terminal").src = window.location.protocol + "//" + window.location.hostname + ":7682";
 </script>


### PR DESCRIPTION
When ssl is enabled for ttyd, it can work with luci ssl. This change aligns with the same behavior for container console, so it can work with luci ssl.