### PR TITLE
修复在openwrt 22.03 出现的若干问题

### DIFF
--- a/applications/luci-app-dockerman/Makefile
+++ b/applications/luci-app-dockerman/Makefile
@@ -6,7 +6,7 @@ LUCI_DEPENDS:=@(aarch64||arm||x86_64) \
 	+luci-lib-docker \
 	+luci-lib-ip \
 	+docker \
-	+dockerd \
+	+dockerd +cgroupfs-mount \
 	+ttyd
 LUCI_PKGARCH:=all
 

--- a/applications/luci-app-dockerman/luasrc/controller/dockerman.lua
+++ b/applications/luci-app-dockerman/luasrc/controller/dockerman.lua
@@ -10,7 +10,7 @@ module("luci.controller.dockerman",package.seeall)
 
 function index()
 	entry({"admin", "docker"},
-		alias("admin", "docker", "config"),
+		firstchild(),
 		_("Docker"),
 		40).acl_depends = { "luci-app-dockerman" }
 

--- a/applications/luci-app-dockerman/luasrc/model/cbi/dockerman/overview.lua
+++ b/applications/luci-app-dockerman/luasrc/model/cbi/dockerman/overview.lua
@@ -124,8 +124,10 @@ if not lost_state then
 	end
 
 	docker_info_table['8IndexServerAddress']._value = docker_info.body.IndexServerAddress
-	for i, v in ipairs(docker_info.body.RegistryConfig.Mirrors) do
-		docker_info_table['9RegistryMirrors']._value = docker_info_table['9RegistryMirrors']._value == "-" and v or (docker_info_table['9RegistryMirrors']._value .. ", " .. v)
+	if docker_info.body.RegistryConfig.Mirrors then
+		for i, v in ipairs(docker_info.body.RegistryConfig.Mirrors) do
+			docker_info_table['9RegistryMirrors']._value = docker_info_table['9RegistryMirrors']._value == "-" and v or (docker_info_table['9RegistryMirrors']._value .. ", " .. v)
+		end
 	end
 
 	s.images_used = 0

--- a/applications/luci-app-dockerman/luasrc/model/cbi/dockerman/overview.lua
+++ b/applications/luci-app-dockerman/luasrc/model/cbi/dockerman/overview.lua
@@ -124,7 +124,7 @@ if not lost_state then
 	end
 
 	docker_info_table['8IndexServerAddress']._value = docker_info.body.IndexServerAddress
-	if docker_info.body.RegistryConfig.Mirrors then
+	if docker_info.body.RegistryConfig and docker_info.body.RegistryConfig.Mirrors then
 		for i, v in ipairs(docker_info.body.RegistryConfig.Mirrors) do
 			docker_info_table['9RegistryMirrors']._value = docker_info_table['9RegistryMirrors']._value == "-" and v or (docker_info_table['9RegistryMirrors']._value .. ", " .. v)
 		end

--- a/applications/luci-app-dockerman/po/zh-cn/dockerman.po
+++ b/applications/luci-app-dockerman/po/zh-cn/dockerman.po
@@ -8,7 +8,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Weblate 4.5.2-dev\n"
+"X-Generator: Weblate 4.10-dev\n"
 
 #: applications/luci-app-dockerman/luasrc/model/cbi/dockerman/newcontainer.lua:619
 msgid "A list of kernel capabilities to add to the container"

--- a/applications/luci-app-dockerman/root/etc/uci-defaults/luci-app-dockerman
+++ b/applications/luci-app-dockerman/root/etc/uci-defaults/luci-app-dockerman
@@ -33,4 +33,5 @@ config_foreach remove_firewall firewall
 # Convert ac_allowed_container to ac_allowed_ports
 (sleep 30s && /etc/init.d/dockerman convert;/etc/init.d/dockerman restart) &
 
+/etc/init.d/dockerd restart &
 exit 0


### PR DESCRIPTION
1. 修复在openwrt 22.03 下不显示二级菜单的问题 #146  #153 
2. 修复openwrt 22.03 下 overview界面报错的问题 #161 
3. 修复openwrt 22.03 下汉化显示不全的问题
4. 开机默认启动docker
5. 增加cgroupfs-mount 依赖