### PR TITLE
Fix nil access crash when image has no RepoTags or RepoDigests

### DIFF
--- a/applications/luci-app-dockerman/luasrc/model/cbi/dockerman/containers.lua
+++ b/applications/luci-app-dockerman/luasrc/model/cbi/dockerman/containers.lua
@@ -85,7 +85,7 @@ function get_containers()
 		end
 		for ii,iv in ipairs(images) do
 			if iv.Id == v.ImageID then
-				data[index]["_image"] = iv.RepoTags and iv.RepoTags[1] or (next(iv.RepoDigests) and (iv.RepoDigests[1]:gsub("(.-)@.+", "%1") .. ":&lt;none&gt;")) or ""
+				data[index]["_image"] = (iv.RepoTags and iv.RepoTags[1]) or (iv.RepoDigests and next(iv.RepoDigests) and (iv.RepoDigests[1]:gsub("(.-)@.+", "%1") .. ":&lt;none&gt;")) or "&lt;none&gt;:&lt;none&gt;"
 			end
 		end
 		data[index]["_id_name"] = '<a href='..luci.dispatcher.build_url("admin/docker/container/"..v.Id)..'  class="dockerman_link" title="'..translate("Container detail")..'">'.. data[index]["_name"] .. "<br><font color='#9f9f9f'>ID: " ..	data[index]["_id"]


### PR DESCRIPTION
## Problem

The containers page crashes with `attempt to index field '?' (a nil value)` when a container references an image that has neither `RepoTags` nor `RepoDigests`.

This commonly occurs with:
- Intermediate build layers from failed/interrupted `docker build` runs
- Locally built images that haven't been tagged
- Orphaned containers referencing deleted images

## Root Cause

Line 88 in `containers.lua` calls `next(iv.RepoDigests)` without first checking if `iv.RepoDigests` is `nil`. In Lua, `next(nil)` throws an error, while `next({})` safely returns `nil`.

```lua
-- Before (crashes when iv.RepoDigests is nil):
data[index]["_image"] = iv.RepoTags and iv.RepoTags[1] or (next(iv.RepoDigests) and ...

-- After (handles all nil cases):
data[index]["_image"] = (iv.RepoTags and iv.RepoTags[1]) or (iv.RepoDigests and next(iv.RepoDigests) and ...) or "<none>:<none>"
```

## Fix

Add a nil check for `iv.RepoDigests` before calling `next()`, and use `<none>:<none>` as the fallback value to match Docker's standard display format for untagged images.

## Testing

Tested on OpenWrt with Docker 27.3.1. Before the fix, the containers page would crash when any container referenced an image with no tags or digests. After the fix, such containers display correctly with `<none>:<none>` as the image name.

Fixes #197