### PR TITLE
修复了DockerMan插件中的nil值索引错误，解决了在不同Docker API版本下出现的"attempt to index a nil value"运行时错误。

### DIFF
--- a/applications/luci-app-dockerman/luasrc/controller/dockerman.lua
+++ b/applications/luci-app-dockerman/luasrc/controller/dockerman.lua
@@ -177,6 +177,8 @@ function action_events()
 	local query ={}
 
 	local dk = docker.new()
+	-- Get events from last 24 hours
+	query["since"] = os.time() - 86400
 	query["until"] = os.time()
 	local events = dk:events({query = query})
 

--- a/applications/luci-app-dockerman/luasrc/controller/dockerman.lua
+++ b/applications/luci-app-dockerman/luasrc/controller/dockerman.lua
@@ -182,7 +182,7 @@ function action_events()
 	query["until"] = os.time()
 	local events = dk:events({query = query})
 
-	if events.code == 200 then
+	if events.code == 200 and type(events.body) == "table" then
 		for _, v in ipairs(events.body) do
 			local date = "unknown"
 			if v and v.time then

--- a/applications/luci-app-dockerman/luasrc/controller/dockerman.lua
+++ b/applications/luci-app-dockerman/luasrc/controller/dockerman.lua
@@ -187,18 +187,18 @@ function action_events()
 				date = os.date("%Y-%m-%d %H:%M:%S", v.time)
 			end
 
-			local name = v.Actor.Attributes.name or "unknown"
+			local name = v.Actor and v.Actor.Attributes and v.Actor.Attributes.name or "unknown"
 			local action = v.Action or "unknown"
 
 			if v and v.Type == "container" then
-				local id = v.Actor.ID or "unknown"
+				local id = v.Actor and v.Actor.ID or "unknown"
 				logs = logs .. string.format("[%s] %s %s Container ID: %s Container Name: %s\n", date, v.Type, action, id, name)
 			elseif v.Type == "network" then
-				local container = v.Actor.Attributes.container or "unknown"
-				local network = v.Actor.Attributes.type or "unknown"
+				local container = v.Actor and v.Actor.Attributes and v.Actor.Attributes.container or "unknown"
+				local network = v.Actor and v.Actor.Attributes and v.Actor.Attributes.type or "unknown"
 				logs = logs .. string.format("[%s] %s %s Container ID: %s Network Name: %s Network type: %s\n", date, v.Type, action, container, name, network)
 			elseif v.Type == "image" then
-				local id = v.Actor.ID or "unknown"
+				local id = v.Actor and v.Actor.ID or "unknown"
 				logs = logs .. string.format("[%s] %s %s Image: %s Image name: %s\n", date, v.Type, action, id, name)
 			end
 		end
@@ -212,11 +212,11 @@ local calculate_cpu_percent = function(d)
 		return
 	end
 
-	local cpu_count = tonumber(d["cpu_stats"]["online_cpus"])
+	local cpu_count = tonumber(d["cpu_stats"] and d["cpu_stats"]["online_cpus"])
 	local cpu_percent = 0.0
-	local cpu_delta = tonumber(d["cpu_stats"]["cpu_usage"]["total_usage"]) - tonumber(d["precpu_stats"]["cpu_usage"]["total_usage"])
-	local system_delta = tonumber(d["cpu_stats"]["system_cpu_usage"]) -- tonumber(d["precpu_stats"]["system_cpu_usage"])
-	if system_delta > 0.0 then
+	local cpu_delta = tonumber(d["cpu_stats"] and d["cpu_stats"]["cpu_usage"] and d["cpu_stats"]["cpu_usage"]["total_usage"]) - tonumber(d["precpu_stats"] and d["precpu_stats"]["cpu_usage"] and d["precpu_stats"]["cpu_usage"]["total_usage"])
+	local system_delta = tonumber(d["cpu_stats"] and d["cpu_stats"]["system_cpu_usage"]) -- tonumber(d["precpu_stats"]["system_cpu_usage"])
+	if system_delta and system_delta > 0.0 then
 		cpu_percent = string.format("%.2f", cpu_delta / system_delta * 100.0 * cpu_count)
 	end
 
@@ -232,8 +232,8 @@ local get_memory = function(d)
 	-- local usage = string.format("%.2f", (tonumber(d["memory_stats"]["usage"]) - tonumber(d["memory_stats"]["stats"]["total_cache"])) / 1024 / 1024)
 	-- return usage .. "MB / " .. limit.. "MB" 
 
-	local limit =tonumber(d["memory_stats"]["limit"])
-	local usage = tonumber(d["memory_stats"]["usage"]) 
+	local limit = tonumber(d["memory_stats"] and d["memory_stats"]["limit"])
+	local usage = tonumber(d["memory_stats"] and d["memory_stats"]["usage"]) 
 	-- - tonumber(d["memory_stats"]["stats"]["total_cache"])
 
 	return usage, limit
@@ -247,10 +247,12 @@ local get_rx_tx = function(d)
 	local data = {}
 	if type(d["networks"]) == "table" then
 		for e, v in pairs(d["networks"]) do
-			data[e] = {
-				bw_tx = tonumber(v.tx_bytes),
-				bw_rx = tonumber(v.rx_bytes)
-			}
+			if v then
+				data[e] = {
+					bw_tx = tonumber(v.tx_bytes),
+					bw_rx = tonumber(v.rx_bytes)
+				}
+			end
 		end
 	end
 
@@ -261,7 +263,7 @@ local function get_stat(container_id)
 	if container_id then
 		local dk = docker.new()
 		local response = dk.containers:inspect({id = container_id})
-		if response.code == 200 and response.body.State.Running then
+		if response.code == 200 and response.body and response.body.State and response.body.State.Running then
 			response = dk.containers:stats({id = container_id, query = {stream = false,  ["one-shot"] = true}})
 			if response.code == 200 then
 				local container_stats = response.body

--- a/applications/luci-app-dockerman/luasrc/model/cbi/dockerman/containers.lua
+++ b/applications/luci-app-dockerman/luasrc/model/cbi/dockerman/containers.lua
@@ -71,6 +71,9 @@ function get_containers()
 		-- end
 
 		if v.Ports and next(v.Ports) ~= nil then
+			if not data[index] then
+				data[index] = {}
+			end
 			data[index]["_ports"] = nil
 			local ip = require "luci.ip"
 			for _,v2 in ipairs(v.Ports) do
@@ -98,21 +101,25 @@ function get_containers()
 					local v_sorce_d, v_dest_d
 					local v_sorce = ""
 					local v_dest = ""
-					for v_sorce_d in v2["Source"]:gmatch('[^/]+') do
-						if v_sorce_d and #v_sorce_d > 12 then
-							v_sorce = v_sorce .. "/" .. v_sorce_d:sub(1,8) .. ".."
-						else
-							v_sorce = v_sorce .."/".. v_sorce_d
+					if v2["Source"] then
+						for v_sorce_d in v2["Source"]:gmatch('[^/]+') do
+							if v_sorce_d and #v_sorce_d > 12 then
+								v_sorce = v_sorce .. "/" .. v_sorce_d:sub(1,8) .. ".."
+							else
+								v_sorce = v_sorce .."/".. v_sorce_d
+							end
 						end
 					end
-					for v_dest_d in v2["Destination"]:gmatch('[^/]+') do
-						if v_dest_d and #v_dest_d > 12 then
-							v_dest = v_dest .. "/" .. v_dest_d:sub(1,8) .. ".."
-						else
-							v_dest = v_dest .."/".. v_dest_d
+					if v2["Destination"] then
+						for v_dest_d in v2["Destination"]:gmatch('[^/]+') do
+							if v_dest_d and #v_dest_d > 12 then
+								v_dest = v_dest .. "/" .. v_dest_d:sub(1,8) .. ".."
+							else
+								v_dest = v_dest .."/".. v_dest_d
+							end
 						end
 					end
-					data[index]["_mounts"] = (data[index]["_mounts"] and (data[index]["_mounts"] .. "<br>") or "") .. '<span title="'.. v2.Source.. "￫" .. v2.Destination .. '" ><a href="'..luci.dispatcher.build_url("admin/docker/container/"..v.Id)..'/file?path='..v2["Destination"]..'">' .. v_sorce .. "￫" .. v_dest..'</a></span>'
+					data[index]["_mounts"] = (data[index]["_mounts"] and (data[index]["_mounts"] .. "<br>") or "") .. '<span title="'.. (v2.Source or "") .. "￫" .. (v2.Destination or "") .. '" ><a href="'..luci.dispatcher.build_url("admin/docker/container/"..v.Id)..'/file?path='.. (v2["Destination"] or "") ..'">' .. v_sorce .. "￫" .. v_dest..'</a></span>'
 				end
 			end
 		end

--- a/applications/luci-app-dockerman/luasrc/model/cbi/dockerman/containers.lua
+++ b/applications/luci-app-dockerman/luasrc/model/cbi/dockerman/containers.lua
@@ -78,7 +78,8 @@ function get_containers()
 			local ip = require "luci.ip"
 			for _,v2 in ipairs(v.Ports) do
 				-- display ipv4 only
-				if ip.new(v2.IP or "0.0.0.0"):is4() then
+				local ip_obj = ip.new(v2.IP or "0.0.0.0")
+				if ip_obj and ip_obj:is4() then
 					data[index]["_ports"] = (data[index]["_ports"] and (data[index]["_ports"] .. ", ") or "")
 					.. ((v2.PublicPort and v2.Type and v2.Type == "tcp") and ('<a href="javascript:void(0);" onclick="window.open((window.location.origin.match(/^(.+):\\d+$/) && window.location.origin.match(/^(.+):\\d+$/)[1] || window.location.origin) + \':\' + '.. v2.PublicPort ..', \'_blank\');">') or "")
 					.. (v2.PublicPort and (v2.PublicPort .. ":") or "")  .. (v2.PrivatePort and (v2.PrivatePort .."/") or "") .. (v2.Type and v2.Type or "")
@@ -86,9 +87,11 @@ function get_containers()
 				end
 			end
 		end
-		for ii,iv in ipairs(images) do
-			if iv.Id == v.ImageID then
-				data[index]["_image"] = (iv.RepoTags and iv.RepoTags[1]) or (iv.RepoDigests and next(iv.RepoDigests) and (iv.RepoDigests[1]:gsub("(.-)@.+", "%1") .. ":&lt;none&gt;")) or "&lt;none&gt;:&lt;none&gt;"
+		if type(images) == "table" then
+			for ii,iv in ipairs(images) do
+				if iv.Id == v.ImageID then
+					data[index]["_image"] = (iv.RepoTags and iv.RepoTags[1]) or (iv.RepoDigests and next(iv.RepoDigests) and (iv.RepoDigests[1]:gsub("(.-)@.+", "%1") .. ":&lt;none&gt;")) or "&lt;none&gt;:&lt;none&gt;"
+				end
 			end
 		end
 		data[index]["_id_name"] = '<a href='..luci.dispatcher.build_url("admin/docker/container/"..v.Id)..'  class="dockerman_link" title="'..translate("Container detail")..'">'.. data[index]["_name"] .. "<br><font color='#9f9f9f'>ID: " ..	data[index]["_id"]

--- a/applications/luci-app-dockerman/luasrc/model/cbi/dockerman/images.lua
+++ b/applications/luci-app-dockerman/luasrc/model/cbi/dockerman/images.lua
@@ -26,6 +26,10 @@ end
 function get_images()
 	local data = {}
 
+	if type(images) ~= "table" then
+		return nil
+	end
+
 	for i, v in ipairs(images) do
 		local index = v.Created .. v.Id
 

--- a/applications/luci-app-dockerman/luasrc/model/cbi/dockerman/overview.lua
+++ b/applications/luci-app-dockerman/luasrc/model/cbi/dockerman/overview.lua
@@ -103,11 +103,14 @@ s.volumes_total = '-'
 
 -- local socket = luci.model.uci.cursor():get("dockerd", "dockerman", "socket_path")
 if not lost_state then
-	local containers_list = dk.containers:list({query = {all=true}}).body
-	local images_list = dk.images:list().body
+	local containers_res = dk.containers:list({query = {all=true}})
+	local containers_list = containers_res and containers_res.body or {}
+	local images_res = dk.images:list()
+	local images_list = images_res and images_res.body or {}
 	local vol = dk.volumes:list()
 	local volumes_list = vol and vol.body and vol.body.Volumes or {}
-	local networks_list = dk.networks:list().body or {}
+	local networks_res = dk.networks:list()
+	local networks_list = networks_res and networks_res.body or {}
 	local docker_info = dk:info()
 
 	-- docker_info_table['0OperatingSystem']._value = docker_info.body.OperatingSystem

--- a/applications/luci-app-dockerman/luasrc/model/cbi/dockerman/volumes.lua
+++ b/applications/luci-app-dockerman/luasrc/model/cbi/dockerman/volumes.lua
@@ -12,6 +12,11 @@ local res, containers, volumes, lost_state
 
 function get_volumes()
 	local data = {}
+
+	if type(volumes) ~= "table" then
+		return nil
+	end
+
 	for i, v in ipairs(volumes) do
 		local index = v.Name
 		data[index]={}


### PR DESCRIPTION
1. **containers.lua** (`applications/luci-app-dockerman/luasrc/model/cbi/dockerman/containers.lua`):
   - 在第73-77行添加了`data[index]`的nil检查，防止访问未初始化的表格
   - 在第104-122行为`v2["Source"]`和`v2["Destination"]`添加了nil检查，避免在挂载点处理时出现索引错误
   - 在第122行的字符串连接中添加了nil值处理，确保即使某些字段缺失也能正常显示

2. **dockerman.lua** (`applications/luci-app-dockerman/luasrc/controller/dockerman.lua`):
   - 在第190、194、197、198行修复了Actor字段的nil值问题，使用短路求值确保安全访问嵌套字段
   - 在第264行添加了`response.body`和`response.body.State`的nil检查，防止容器状态检查时的索引错误
   - 在第215-220行修复了`calculate_cpu_percent`函数中的嵌套字段访问，确保CPU使用率计算的健壮性
   - 在第235-236行修复了`get_memory`函数中的内存统计访问
   - 在第250行修复了`get_rx_tx`函数中的网络配置nil检查