### PR TITLE
fix nil

### DIFF
--- a/applications/luci-app-dockerman/luasrc/model/cbi/dockerman/newcontainer.lua
+++ b/applications/luci-app-dockerman/luasrc/model/cbi/dockerman/newcontainer.lua
@@ -384,7 +384,7 @@ elseif cmd_line and cmd_line:match("^duplicate/[^/]+$") then
 		-- default_config.network = create_body.HostConfig.NetworkMode == "default" and "bridge" or create_body.HostConfig.NetworkMode
 		-- if container has leave original network, and add new network, .HostConfig.NetworkMode is INcorrect, so using first child of .NetworkingConfig.EndpointsConfig
 		default_config.network = create_body.NetworkingConfig and create_body.NetworkingConfig.EndpointsConfig and next(create_body.NetworkingConfig.EndpointsConfig) or nil
-		default_config.ip = default_config.network and default_config.network ~= "bridge" and default_config.network ~= "host" and default_config.network ~= "null" and create_body.NetworkingConfig.EndpointsConfig[default_config.network].IPAMConfig and create_body.NetworkingConfig.EndpointsConfig[default_config.network].IPAMConfig.IPv4Address or nil
+		default_config.ip = default_config.network and default_config.network ~= "bridge" and default_config.network ~= "host" and default_config.network ~= "null" and create_body.NetworkingConfig.EndpointsConfig[default_config.network] and create_body.NetworkingConfig.EndpointsConfig[default_config.network].IPAMConfig and create_body.NetworkingConfig.EndpointsConfig[default_config.network].IPAMConfig.IPv4Address or nil
 		default_config.link = create_body.HostConfig.Links
 		default_config.env = create_body.Env
 		default_config.dns = create_body.HostConfig.Dns


### PR DESCRIPTION
create_body.NetworkingConfig.EndpointsConfig[default_config.network] 是否为 nil，就直接访问了 .IPAMConfig 。如果这个值为 nil，会导致运行时错误。